### PR TITLE
[StmtKitsune][SemaStmt][CGKitsune] Draft change to use random-access …

### DIFF
--- a/clang/include/clang/AST/StmtKitsune.h
+++ b/clang/include/clang/AST/StmtKitsune.h
@@ -168,7 +168,19 @@ public:
 /// can be extracted using getLoopVariable and getRangeInit.
 class CXXForallRangeStmt : public Stmt {
   SourceLocation ForLoc;
-  enum { INIT, RANGE, BEGINSTMT, ENDSTMT, COND, INC, LOOPVAR, BODY, END };
+  enum {
+    INIT,
+    RANGE,
+    BEGINSTMT,
+    ENDSTMT,
+    INDEXSTMT,
+    INDEXENDSTMT,
+    COND,
+    INC,
+    LOOPVAR,
+    BODY,
+    END
+  };
   // SubExprs[RANGE] is an expression or declstmt.
   // SubExprs[COND] and SubExprs[INC] are expressions.
   Stmt *SubExprs[END];
@@ -179,10 +191,11 @@ class CXXForallRangeStmt : public Stmt {
   friend class ASTStmtReader;
 public:
   CXXForallRangeStmt(Stmt *InitStmt, DeclStmt *Range, DeclStmt *Begin,
-                  DeclStmt *End, Expr *Cond, Expr *Inc, DeclStmt *LoopVar,
-                  Stmt *Body, SourceLocation FL, SourceLocation CAL,
-                  SourceLocation CL, SourceLocation RPL);
-  CXXForallRangeStmt(EmptyShell Empty) : Stmt(CXXForallRangeStmtClass, Empty) { }
+                     DeclStmt *End, DeclStmt *Index, DeclStmt *IndexEnd,
+                     Expr *Cond, Expr *Inc, DeclStmt *LoopVar, Stmt *Body,
+                     SourceLocation FL, SourceLocation CAL, SourceLocation CL,
+                     SourceLocation RPL);
+  CXXForallRangeStmt(EmptyShell Empty) : Stmt(CXXForallRangeStmtClass, Empty) {}
 
   Stmt *getInit() { return SubExprs[INIT]; }
   VarDecl *getLoopVariable();
@@ -198,6 +211,12 @@ public:
     return cast_or_null<DeclStmt>(SubExprs[BEGINSTMT]);
   }
   DeclStmt *getEndStmt() { return cast_or_null<DeclStmt>(SubExprs[ENDSTMT]); }
+  DeclStmt *getIndexStmt() {
+    return cast_or_null<DeclStmt>(SubExprs[INDEXSTMT]);
+  }
+  DeclStmt *getIndexEndStmt() {
+    return cast_or_null<DeclStmt>(SubExprs[INDEXENDSTMT]);
+  }
   Expr *getCond() { return cast_or_null<Expr>(SubExprs[COND]); }
   Expr *getInc() { return cast_or_null<Expr>(SubExprs[INC]); }
   DeclStmt *getLoopVarStmt() { return cast<DeclStmt>(SubExprs[LOOPVAR]); }
@@ -211,6 +230,12 @@ public:
   }
   const DeclStmt *getEndStmt() const {
     return cast_or_null<DeclStmt>(SubExprs[ENDSTMT]);
+  }
+  const DeclStmt *getIndexStmt() const {
+    return cast_or_null<DeclStmt>(SubExprs[INDEXSTMT]);
+  }
+  const DeclStmt *getIndexEndStmt() const {
+    return cast_or_null<DeclStmt>(SubExprs[INDEXENDSTMT]);
   }
   const Expr *getCond() const {
     return cast_or_null<Expr>(SubExprs[COND]);
@@ -228,6 +253,8 @@ public:
   void setRangeStmt(Stmt *S) { SubExprs[RANGE] = S; }
   void setBeginStmt(Stmt *S) { SubExprs[BEGINSTMT] = S; }
   void setEndStmt(Stmt *S) { SubExprs[ENDSTMT] = S; }
+  void setIndexStmt(Stmt *S) { SubExprs[INDEXSTMT] = S; }
+  void setIndexEndStmt(Stmt *S) { SubExprs[INDEXENDSTMT] = S; }
   void setCond(Expr *E) { SubExprs[COND] = reinterpret_cast<Stmt*>(E); }
   void setInc(Expr *E) { SubExprs[INC] = reinterpret_cast<Stmt*>(E); }
   void setLoopVarStmt(Stmt *S) { SubExprs[LOOPVAR] = S; }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -4336,15 +4336,11 @@ public:
                                   SourceLocation ColonLoc, Expr *Collection,
                                   SourceLocation RParenLoc,
                                   BuildForRangeKind Kind);
-  StmtResult BuildCXXForallRangeStmt(SourceLocation ForLoc,
-                                  SourceLocation CoawaitLoc,
-                                  Stmt *InitStmt,
-                                  SourceLocation ColonLoc,
-                                  Stmt *RangeDecl, Stmt *Begin, Stmt *End,
-                                  Expr *Cond, Expr *Inc,
-                                  Stmt *LoopVarDecl,
-                                  SourceLocation RParenLoc,
-                                  BuildForRangeKind Kind);
+  StmtResult BuildCXXForallRangeStmt(
+      SourceLocation ForLoc, SourceLocation CoawaitLoc, Stmt *InitStmt,
+      SourceLocation ColonLoc, Stmt *RangeDecl, Stmt *Begin, Stmt *End,
+      Stmt *Index, Stmt *IndexEnd, Expr *Cond, Expr *Inc, Stmt *LoopVarDecl,
+      SourceLocation RParenLoc, BuildForRangeKind Kind);
   StmtResult FinishCXXForallRangeStmt(Stmt *ForRange, Stmt *Body);
 
   StmtResult ActOnReturnStmt(SourceLocation ReturnLoc, Expr *RetValExp,

--- a/clang/lib/AST/StmtCXX.cpp
+++ b/clang/lib/AST/StmtCXX.cpp
@@ -84,19 +84,21 @@ const VarDecl *CXXForRangeStmt::getLoopVariable() const {
   return const_cast<CXXForRangeStmt *>(this)->getLoopVariable();
 }
 
-
 CXXForallRangeStmt::CXXForallRangeStmt(Stmt *Init, DeclStmt *Range,
-                                 DeclStmt *BeginStmt, DeclStmt *EndStmt,
-                                 Expr *Cond, Expr *Inc, DeclStmt *LoopVar,
-                                 Stmt *Body, SourceLocation FL,
-                                 SourceLocation CAL, SourceLocation CL,
-                                 SourceLocation RPL)
+                                       DeclStmt *BeginStmt, DeclStmt *EndStmt,
+                                       DeclStmt *IndexStmt,
+                                       DeclStmt *IndexEndStmt, Expr *Cond,
+                                       Expr *Inc, DeclStmt *LoopVar, Stmt *Body,
+                                       SourceLocation FL, SourceLocation CAL,
+                                       SourceLocation CL, SourceLocation RPL)
     : Stmt(CXXForallRangeStmtClass), ForLoc(FL), CoawaitLoc(CAL), ColonLoc(CL),
       RParenLoc(RPL) {
   SubExprs[INIT] = Init;
   SubExprs[RANGE] = Range;
   SubExprs[BEGINSTMT] = BeginStmt;
   SubExprs[ENDSTMT] = EndStmt;
+  SubExprs[INDEXSTMT] = IndexStmt;
+  SubExprs[INDEXENDSTMT] = IndexEndStmt;
   SubExprs[COND] = Cond;
   SubExprs[INC] = Inc;
   SubExprs[LOOPVAR] = LoopVar;

--- a/clang/lib/CodeGen/CGKitsune.cpp
+++ b/clang/lib/CodeGen/CGKitsune.cpp
@@ -416,6 +416,8 @@ void CodeGenFunction::EmitCXXForallRangeStmt(const CXXForallRangeStmt &S,
   EmitStmt(S.getRangeStmt());
   EmitStmt(S.getBeginStmt());
   EmitStmt(S.getEndStmt());
+  EmitStmt(S.getIndexStmt());
+  EmitStmt(S.getIndexEndStmt());
 
   // create the sync region
   PushSyncRegion();
@@ -455,7 +457,7 @@ void CodeGenFunction::EmitCXXForallRangeStmt(const CXXForallRangeStmt &S,
   EmitBlock(Detach);
 
   // Extract the DeclStmt from the statement init
-  const DeclStmt *DS = cast<DeclStmt>(S.getBeginStmt());
+  const DeclStmt *DS = cast<DeclStmt>(S.getIndexStmt());
   
   // Set up IVs to be copied as firstprivate 
   auto OldAllocaInsertPt = AllocaInsertPt;

--- a/clang/lib/Sema/SemaStmt.cpp
+++ b/clang/lib/Sema/SemaStmt.cpp
@@ -2502,13 +2502,11 @@ struct InvalidateOnErrorScope {
 }
 
 /// BuildCXXForallRangeStmt - Build or instantiate a C++11 for-range statement.
-StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
-                                      SourceLocation CoawaitLoc, Stmt *InitStmt,
-                                      SourceLocation ColonLoc, Stmt *RangeDecl,
-                                      Stmt *Begin, Stmt *End, Expr *Cond,
-                                      Expr *Inc, Stmt *LoopVarDecl,
-                                      SourceLocation RParenLoc,
-                                      BuildForRangeKind Kind) {
+StmtResult Sema::BuildCXXForallRangeStmt(
+    SourceLocation ForLoc, SourceLocation CoawaitLoc, Stmt *InitStmt,
+    SourceLocation ColonLoc, Stmt *RangeDecl, Stmt *Begin, Stmt *End,
+    Stmt *Index, Stmt *IndexEnd, Expr *Cond, Expr *Inc, Stmt *LoopVarDecl,
+    SourceLocation RParenLoc, BuildForRangeKind Kind) {
   // FIXME: This should not be used during template instantiation. We should
   // pick up the set of unqualified lookup results for the != and + operators
   // in the initial parse.
@@ -2534,6 +2532,8 @@ StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
 
   StmtResult BeginDeclStmt = Begin;
   StmtResult EndDeclStmt = End;
+  StmtResult IndexDeclStmt = Index;
+  StmtResult IndexEndDeclStmt = IndexEnd;
   ExprResult NotEqExpr = Cond, IncrExpr = Inc;
 
   if (RangeVarType->isDependentType()) {
@@ -2757,9 +2757,82 @@ StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
     if (EndRef.isInvalid())
       return StmtError();
 
-    // Build and check __begin != __end expression.
-    NotEqExpr = ActOnBinOp(S, ColonLoc, tok::exclaimequal,
-                           BeginRef.get(), EndRef.get());
+    // Create a variable __index of the iterator's difference type
+    // that starts at (__begin - __begin) and ends at (__end -
+    // __begin).  Make the LoopVar equal to *(__begin + __index), and
+    // use __index as the IV of the loop.
+
+    // Build and check __end - __begin expression.
+    ExprResult DiffExpr =
+        ActOnBinOp(S, ColonLoc, tok::minus, EndRef.get(), BeginRef.get());
+    // if (!DiffExpr.isInvalid())
+    //   DiffExpr = CheckBooleanCondition(ColonLoc, DiffExpr.get());
+    if (!DiffExpr.isInvalid())
+      DiffExpr = ActOnFinishFullExpr(DiffExpr.get(), /*DiscardedValue*/ false);
+    if (DiffExpr.isInvalid()) {
+      Diag(RangeLoc, diag::note_for_range_invalid_iterator)
+        << RangeLoc << 0 << BeginRangeRef.get()->getType();
+      NoteForRangeBeginEndFunction(*this, BeginExpr.get(), BEF_begin);
+      if (!Context.hasSameType(BeginType, EndType))
+        NoteForRangeBeginEndFunction(*this, EndExpr.get(), BEF_end);
+      return StmtError();
+    }
+
+    // Build and check __begin - __begin expression to initialize
+    // IndexVar.  We compute __begin - __begin because it's not clear
+    // that an arbirary difference_type for an arbitrary
+    // RandomAccessIterator has a way to statically construct a zero
+    // difference.
+    ExprResult InitExpr =
+        ActOnBinOp(S, ColonLoc, tok::minus, BeginRef.get(), BeginRef.get());
+    // if (!InitExpr.isInvalid())
+    //   InitExpr = CheckBooleanCondition(ColonLoc, InitExpr.get());
+    if (!InitExpr.isInvalid())
+      InitExpr = ActOnFinishFullExpr(InitExpr.get(), /*DiscardedValue*/ false);
+    if (InitExpr.isInvalid()) {
+      Diag(RangeLoc, diag::note_for_range_invalid_iterator)
+          << RangeLoc << 0 << BeginRangeRef.get()->getType();
+      NoteForRangeBeginEndFunction(*this, BeginExpr.get(), BEF_begin);
+      // if (!Context.hasSameType(BeginType, EndType))
+      //   NoteForRangeBeginEndFunction(*this, EndExpr.get(), BEF_end);
+      return StmtError();
+    }
+
+    QualType IndexType = DiffExpr.get()->getType();
+    VarDecl *IndexVar = BuildForRangeVarDecl(*this, ColonLoc, IndexType,
+                                             std::string("__index") + DepthStr);
+    VarDecl *IndexEndVar = BuildForRangeVarDecl(
+        *this, ColonLoc, IndexType, std::string("__index_end") + DepthStr);
+
+    AddInitializerToDecl(IndexVar, InitExpr.get(), /*DirectInit=*/false);
+    FinalizeDeclaration(IndexVar);
+    CurContext->addHiddenDecl(IndexVar);
+
+    AddInitializerToDecl(IndexEndVar, DiffExpr.get(), /*DirectInit=*/false);
+    FinalizeDeclaration(IndexEndVar);
+    CurContext->addHiddenDecl(IndexEndVar);
+
+    IndexDeclStmt =
+        ActOnDeclStmt(ConvertDeclToDeclGroup(IndexVar), ColonLoc, ColonLoc);
+    IndexEndDeclStmt =
+        ActOnDeclStmt(ConvertDeclToDeclGroup(IndexEndVar), ColonLoc, ColonLoc);
+
+    const QualType IndexRefNonRefType =
+        IndexVar->getType().getNonReferenceType();
+    ExprResult IndexRef =
+        BuildDeclRefExpr(IndexVar, IndexRefNonRefType, VK_LValue, ColonLoc);
+    if (IndexRef.isInvalid())
+      return StmtError();
+
+    ExprResult IndexEndRef = BuildDeclRefExpr(
+        IndexEndVar, IndexEndVar->getType().getNonReferenceType(), VK_LValue,
+        ColonLoc);
+    if (IndexEndRef.isInvalid())
+      return StmtError();
+
+    // Build and check __index <= __index_end expression.
+    NotEqExpr = ActOnBinOp(S, ColonLoc, tok::lessequal, IndexRef.get(),
+                           IndexEndRef.get());
     if (!NotEqExpr.isInvalid())
       NotEqExpr = CheckBooleanCondition(ColonLoc, NotEqExpr.get());
     if (!NotEqExpr.isInvalid())
@@ -2774,13 +2847,13 @@ StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
       return StmtError();
     }
 
-    // Build and check ++__begin expression.
-    BeginRef = BuildDeclRefExpr(BeginVar, BeginRefNonRefType,
-                                VK_LValue, ColonLoc);
-    if (BeginRef.isInvalid())
+    // Build and check ++__index expression.
+    IndexRef =
+        BuildDeclRefExpr(IndexVar, IndexRefNonRefType, VK_LValue, ColonLoc);
+    if (IndexRef.isInvalid())
       return StmtError();
 
-    IncrExpr = ActOnUnaryOp(S, ColonLoc, tok::plusplus, BeginRef.get());
+    IncrExpr = ActOnUnaryOp(S, ColonLoc, tok::plusplus, IndexRef.get());
     if (!IncrExpr.isInvalid() && CoawaitLoc.isValid())
       // FIXME: getCurScope() should not be used during template instantiation.
       // We should pick up the set of unqualified lookup results for operator
@@ -2790,18 +2863,33 @@ StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
       IncrExpr = ActOnFinishFullExpr(IncrExpr.get(), /*DiscardedValue*/ false);
     if (IncrExpr.isInvalid()) {
       Diag(RangeLoc, diag::note_for_range_invalid_iterator)
-        << RangeLoc << 2 << BeginRangeRef.get()->getType() ;
+        << RangeLoc << 2 << IndexRef.get()->getType() ;
+      // NoteForRangeBeginEndFunction(*this, BeginExpr.get(), BEF_begin);
+      return StmtError();
+    }
+
+    // Build and check *(__begin + __index)  expression.
+    BeginRef =
+        BuildDeclRefExpr(BeginVar, BeginRefNonRefType, VK_LValue, ColonLoc);
+    if (BeginRef.isInvalid())
+      return StmtError();
+
+    IndexRef =
+        BuildDeclRefExpr(IndexVar, IndexRefNonRefType, VK_LValue, ColonLoc);
+    if (IndexRef.isInvalid())
+      return StmtError();
+
+    ExprResult PtrAddExpr =
+        ActOnBinOp(S, ColonLoc, tok::plus, BeginRef.get(), IndexRef.get());
+    if (PtrAddExpr.isInvalid()) {
+      Diag(RangeLoc, diag::note_for_range_invalid_iterator)
+        << RangeLoc << 1 << BeginRangeRef.get()->getType();
       NoteForRangeBeginEndFunction(*this, BeginExpr.get(), BEF_begin);
       return StmtError();
     }
 
-    // Build and check *__begin  expression.
-    BeginRef = BuildDeclRefExpr(BeginVar, BeginRefNonRefType,
-                                VK_LValue, ColonLoc);
-    if (BeginRef.isInvalid())
-      return StmtError();
-
-    ExprResult DerefExpr = ActOnUnaryOp(S, ColonLoc, tok::star, BeginRef.get());
+    ExprResult DerefExpr =
+        ActOnUnaryOp(S, ColonLoc, tok::star, PtrAddExpr.get());
     if (DerefExpr.isInvalid()) {
       Diag(RangeLoc, diag::note_for_range_invalid_iterator)
         << RangeLoc << 1 << BeginRangeRef.get()->getType();
@@ -2809,8 +2897,8 @@ StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
       return StmtError();
     }
 
-    // Attach  *__begin  as initializer for VD. Don't touch it if we're just
-    // trying to determine whether this would be a valid range.
+    // Attach  *(__begin + __index)  as initializer for VD. Don't touch it if
+    // we're just trying to determine whether this would be a valid range.
     if (!LoopVar->isInvalidDecl() && Kind != BFRK_Check) {
       AddInitializerToDecl(LoopVar, DerefExpr.get(), /*DirectInit=*/false);
       if (LoopVar->isInvalidDecl())
@@ -2825,9 +2913,11 @@ StmtResult Sema::BuildCXXForallRangeStmt(SourceLocation ForLoc,
 
   return new (Context) CXXForallRangeStmt(
       InitStmt, RangeDS, cast_or_null<DeclStmt>(BeginDeclStmt.get()),
-      cast_or_null<DeclStmt>(EndDeclStmt.get()), NotEqExpr.get(),
-      IncrExpr.get(), LoopVarDS, /*Body=*/nullptr, ForLoc, CoawaitLoc,
-      ColonLoc, RParenLoc);
+      cast_or_null<DeclStmt>(EndDeclStmt.get()),
+      cast_or_null<DeclStmt>(IndexDeclStmt.get()),
+      cast_or_null<DeclStmt>(IndexEndDeclStmt.get()), NotEqExpr.get(),
+      IncrExpr.get(), LoopVarDS, /*Body=*/nullptr, ForLoc, CoawaitLoc, ColonLoc,
+      RParenLoc);
 }
 
 /// BuildCXXForRangeStmt - Build or instantiate a C++11 for-range statement.
@@ -4063,7 +4153,8 @@ StmtResult Sema::ActOnCXXForallRangeStmt(Scope *S, SourceLocation ForLoc,
 
   return BuildCXXForallRangeStmt(
       ForLoc, CoawaitLoc, InitStmt, ColonLoc, RangeDecl.get(),
-      /*BeginStmt=*/nullptr, /*EndStmt=*/nullptr,
+      /*BeginStmt=*/nullptr, /*EndStmt=*/nullptr, /*IndexStmt=*/nullptr,
+      /*IndexEndStmt=*/nullptr,
       /*Cond=*/nullptr, /*Inc=*/nullptr, DS, RParenLoc, Kind);
 }
 

--- a/clang/lib/Sema/TreeTransform.h
+++ b/clang/lib/Sema/TreeTransform.h
@@ -2203,11 +2203,12 @@ public:
   }
 
   StmtResult RebuildCXXForallRangeStmt(SourceLocation ForLoc,
-                                    SourceLocation CoawaitLoc, Stmt *Init,
-                                    SourceLocation ColonLoc, Stmt *Range,
-                                    Stmt *Begin, Stmt *End, Expr *Cond,
-                                    Expr *Inc, Stmt *LoopVar,
-                                    SourceLocation RParenLoc) {
+                                       SourceLocation CoawaitLoc, Stmt *Init,
+                                       SourceLocation ColonLoc, Stmt *Range,
+                                       Stmt *Begin, Stmt *End, Stmt *Index,
+                                       Stmt *IndexEnd, Expr *Cond, Expr *Inc,
+                                       Stmt *LoopVar,
+                                       SourceLocation RParenLoc) {
     // If we've just learned that the range is actually an Objective-C
     // collection, treat this as an Objective-C fast enumeration loop.
     if (DeclStmt *RangeStmt = dyn_cast<DeclStmt>(Range)) {
@@ -2233,9 +2234,9 @@ public:
       }
     }
 
-    return getSema().BuildCXXForallRangeStmt(ForLoc, CoawaitLoc, Init, ColonLoc,
-                                          Range, Begin, End, Cond, Inc, LoopVar,
-                                          RParenLoc, Sema::BFRK_Rebuild);
+    return getSema().BuildCXXForallRangeStmt(
+        ForLoc, CoawaitLoc, Init, ColonLoc, Range, Begin, End, Index, IndexEnd,
+        Cond, Inc, LoopVar, RParenLoc, Sema::BFRK_Rebuild);
   }
 
   /// Build a new C++0x range-based for statement.
@@ -7930,6 +7931,12 @@ TreeTransform<Derived>::TransformCXXForallRangeStmt(CXXForallRangeStmt *S) {
   StmtResult End = getDerived().TransformStmt(S->getEndStmt());
   if (End.isInvalid())
     return StmtError();
+  StmtResult Index = getDerived().TransformStmt(S->getIndexStmt());
+  if (Index.isInvalid())
+    return StmtError();
+  StmtResult IndexEnd = getDerived().TransformStmt(S->getIndexEndStmt());
+  if (IndexEnd.isInvalid())
+    return StmtError();
 
   ExprResult Cond = getDerived().TransformExpr(S->getCond());
   if (Cond.isInvalid())
@@ -7957,16 +7964,15 @@ TreeTransform<Derived>::TransformCXXForallRangeStmt(CXXForallRangeStmt *S) {
       Range.get() != S->getRangeStmt() ||
       Begin.get() != S->getBeginStmt() ||
       End.get() != S->getEndStmt() ||
+      Index.get() != S->getIndexStmt() ||
+      IndexEnd.get() != S->getIndexEndStmt() ||
       Cond.get() != S->getCond() ||
       Inc.get() != S->getInc() ||
       LoopVar.get() != S->getLoopVarStmt()) {
-    NewStmt = getDerived().RebuildCXXForallRangeStmt(S->getForLoc(),
-                                                  S->getCoawaitLoc(), Init.get(),
-                                                  S->getColonLoc(), Range.get(),
-                                                  Begin.get(), End.get(),
-                                                  Cond.get(),
-                                                  Inc.get(), LoopVar.get(),
-                                                  S->getRParenLoc());
+    NewStmt = getDerived().RebuildCXXForallRangeStmt(
+        S->getForLoc(), S->getCoawaitLoc(), Init.get(), S->getColonLoc(),
+        Range.get(), Begin.get(), End.get(), Index.get(), IndexEnd.get(),
+        Cond.get(), Inc.get(), LoopVar.get(), S->getRParenLoc());
     if (NewStmt.isInvalid())
       return StmtError();
   }
@@ -7978,13 +7984,10 @@ TreeTransform<Derived>::TransformCXXForallRangeStmt(CXXForallRangeStmt *S) {
   // Body has changed but we didn't rebuild the for-range statement. Rebuild
   // it now so we have a new statement to attach the body to.
   if (Body.get() != S->getBody() && NewStmt.get() == S) {
-    NewStmt = getDerived().RebuildCXXForallRangeStmt(S->getForLoc(),
-                                                     S->getCoawaitLoc(), Init.get(),
-                                                     S->getColonLoc(), Range.get(),
-                                                     Begin.get(), End.get(),
-                                                     Cond.get(),
-                                                     Inc.get(), LoopVar.get(),
-                                                     S->getRParenLoc());
+    NewStmt = getDerived().RebuildCXXForallRangeStmt(
+        S->getForLoc(), S->getCoawaitLoc(), Init.get(), S->getColonLoc(),
+        Range.get(), Begin.get(), End.get(), Index.get(), IndexEnd.get(),
+        Cond.get(), Inc.get(), LoopVar.get(), S->getRParenLoc());
     if (NewStmt.isInvalid())
       return StmtError();
   }


### PR DESCRIPTION
…iterator methods to generate code for CXXForallRange loops, to ensure these loops are generally semantically amenable to divide-and-conquer (DAC) loop spawning.  This change addresses issues with CXXForallRange loops not getting transformed using DAC loop spawning without significant compiler inlining and optimization, which isn't always possible.