### PR TITLE
From TB for alloca insertion point bug fix.  

### DIFF
--- a/clang/lib/CodeGen/CGKitsune.cpp
+++ b/clang/lib/CodeGen/CGKitsune.cpp
@@ -463,7 +463,7 @@ void CodeGenFunction::EmitCXXForallRangeStmt(const CXXForallRangeStmt &S,
   auto OldAllocaInsertPt = AllocaInsertPt;
   llvm::Value *Undef = llvm::UndefValue::get(Int32Ty);
   AllocaInsertPt = new llvm::BitCastInst(Undef, Int32Ty, "",
-                                             Detach);
+                                             ForBody);
   
   DeclMapTy IVDeclMap; 
   llvm::SmallVector<


### PR DESCRIPTION


Move task-local alloca insertion point for parallel-for loops into the detached block.  Because the detached block will be moved to an outlined helper function even at -O0, this change helps ensure that stack memory is used efficiently for parallel-for loops at all optimization levels.  In particular, this change resolves a segmentation fault when a parallel-for loop over many iterations is compiled at -O0 and run.