### PR TITLE
Updates for new cilktools 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 
 # External projects 
 /cheetah 
+/cilktools
 
 #==============================================================================#
 # Explicit files to ignore (only matches one).

--- a/kitsune/cmake/caches/kitsune-dev.cmake
+++ b/kitsune/cmake/caches/kitsune-dev.cmake
@@ -32,7 +32,7 @@ set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING "")
 # you are working on.  By default we provide the full suite of
 # clang+tools, openmp, lld, and a debugger via lldb.
 set(LLVM_ENABLE_PROJECTS
-  clang;openmp;
+  clang;openmp
   CACHE STRING "")
 
 message(DEBUG "  --> KITSUNE-DEV - enabled LLVM projects: ${LLVM_ENABLE_PROJECTS}")
@@ -63,7 +63,7 @@ set(CLANG_CONFIG_FILE_USER_DIR "$ENV{HOME}/.kitsune" CACHE STRING "")
  set(CUDA_HOST_COMPILER "/usr/bin/gcc-8" CACHE STRING "")
 #endif()
 
-set(_runtimes_list "cheetah")
+set(_runtimes_list "cheetah;cilktools")
 
 # Various helpful LLVM-level settings for development/debugging.
 set(LLVM_ENABLE_WARNINGS OFF CACHE BOOL "")    # sometimes errors get lost in all the warnings...

--- a/kitsune/examples/kokkos/CMakeLists.txt
+++ b/kitsune/examples/kokkos/CMakeLists.txt
@@ -57,7 +57,6 @@ set(_example_srcs
 
 set(_example_view_srcs
   raytrace.cpp
-  vecadd-views.cpp
   )
 
 # Build the pure-kokkos serial target version of all the examples first.

--- a/llvm/include/llvm/Analysis/MemoryBuiltins.h
+++ b/llvm/include/llvm/Analysis/MemoryBuiltins.h
@@ -170,10 +170,13 @@ inline CallInst *extractCallocCall(Value *I, const TargetLibraryInfo *TLI) {
 bool isLibFreeFunction(const Function *F, const LibFunc TLIFn);
 
 /// isFreeCall - Returns non-null if the value is a call to the builtin free()
-const CallInst *isFreeCall(const Value *I, const TargetLibraryInfo *TLI);
+const CallInst *isFreeCall(const Value *I, const TargetLibraryInfo *TLI,
+                           bool IgnoreBuiltinAttr = false);
 
-inline CallInst *isFreeCall(Value *I, const TargetLibraryInfo *TLI) {
-  return const_cast<CallInst*>(isFreeCall((const Value*)I, TLI));
+inline CallInst *isFreeCall(Value *I, const TargetLibraryInfo *TLI,
+                            bool IgnoreBuiltinAttr = false) {
+  return const_cast<CallInst *>(
+      isFreeCall((const Value *)I, TLI, IgnoreBuiltinAttr));
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Analysis/MemoryBuiltins.cpp
+++ b/llvm/lib/Analysis/MemoryBuiltins.cpp
@@ -465,11 +465,12 @@ bool llvm::isLibFreeFunction(const Function *F, const LibFunc TLIFn) {
 }
 
 /// isFreeCall - Returns non-null if the value is a call to the builtin free()
-const CallInst *llvm::isFreeCall(const Value *I, const TargetLibraryInfo *TLI) {
+const CallInst *llvm::isFreeCall(const Value *I, const TargetLibraryInfo *TLI,
+                                 bool IgnoreBuiltinAttr) {
   bool IsNoBuiltinCall;
   const Function *Callee =
       getCalledFunction(I, /*LookThroughBitCast=*/false, IsNoBuiltinCall);
-  if (Callee == nullptr || IsNoBuiltinCall)
+  if (Callee == nullptr || (IsNoBuiltinCall && !IgnoreBuiltinAttr))
     return nullptr;
 
   StringRef FnName = Callee->getName();

--- a/llvm/projects/CMakeLists.txt
+++ b/llvm/projects/CMakeLists.txt
@@ -13,7 +13,8 @@ foreach(entry ${entries})
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/parallel-libs) AND
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/openmp) AND
        (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/debuginfo-tests) AND
-       (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/cheetah))
+       (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/cheetah)
+       (NOT ${entry} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/cliktools))
       get_filename_component(entry_name "${entry}" NAME)
       add_llvm_external_project(${entry_name})
     endif()
@@ -30,6 +31,7 @@ if(${LLVM_BUILD_RUNTIME})
   if(NOT MSVC OR LLVM_FORCE_BUILD_RUNTIME)
     # Add the projects in reverse order of their dependencies so that the
     # dependent projects can see the target names of their dependencies.
+    add_llvm_external_project(cilktools)
     add_llvm_external_project(cheetah)
     add_llvm_external_project(libunwind)
     add_llvm_external_project(pstl)

--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -17,6 +17,11 @@ FetchContent_Declare(cheetahrt
   GIT_TAG           opencilk/v1.0
   SOURCE_DIR        ${CMAKE_CURRENT_SOURCE_DIR}/../../cheetah)
 
+FetchContent_Declare(cilktools
+  GIT_REPOSITORY   https://github.com/OpenCilk/productivity-tools.git
+  GIT_TAG          opencilk/v1.0
+  SOURCE_DIR       ${CMAKE_CURRENT_SOURCE_DIR}/../../cilktools)
+
 # Find all subdirectories containing CMake projects
 file(GLOB entries *)
 foreach(entry ${entries})
@@ -26,7 +31,7 @@ foreach(entry ${entries})
 endforeach()
 
 # Side-by-side subprojects layout.
-set(LLVM_ALL_RUNTIMES "libcxx;libcxxabi;libunwind;compiler-rt;cheetah;kitsune")
+set(LLVM_ALL_RUNTIMES "libcxx;libcxxabi;libunwind;compiler-rt;cheetah;cilktools;kitsune")
 set(LLVM_ENABLE_RUNTIMES "" CACHE STRING
   "Semicolon-separated list of runtimes to build (${LLVM_ALL_RUNTIMES}), or \"all\".")
 if(LLVM_ENABLE_RUNTIMES STREQUAL "all" )
@@ -38,6 +43,14 @@ if ("cheetah" IN_LIST LLVM_ENABLE_RUNTIMES)
   if (NOT cheetahrt_POPULATED)
     message(STATUS "NOTE: <<<< fetching cheetah runtime source via git... >>>>")
     FetchContent_Populate(cheetahrt)
+  endif()
+endif()
+
+if ("cilktools" IN_LIST LLVM_ENABLE_RUNTIMES)
+  FetchContent_GetProperties(cilktools)
+  if (NOT cilktools_POPULATED)
+    message(STATUS "NOTE: <<<< fetching cilktools source via git... >>>>")
+    FetchContent_Populate(cilktools)
   endif()
 endif()
 


### PR DESCRIPTION
The cilktools have been separated from compiler-rt and now live in their own repo.  This PR addresses that change by adding them as an LLVM runtime target but does not yet remove them from our compiler-rt code. It also has some updates that were missing from the kitsune repo for correct functioning of the tools.  

