### PR TITLE
dev/18.x linking error fixes

### DIFF
--- a/clang/lib/Frontend/CMakeLists.txt
+++ b/clang/lib/Frontend/CMakeLists.txt
@@ -7,6 +7,7 @@ set(LLVM_LINK_COMPONENTS
   ProfileData
   Support
   TargetParser
+  TapirOpts
   )
 
 add_clang_library(clangFrontend

--- a/llvm/lib/Transforms/Tapir/CMakeLists.txt
+++ b/llvm/lib/Transforms/Tapir/CMakeLists.txt
@@ -45,6 +45,7 @@ add_llvm_component_library(LLVMTapirOpts
   Support
   TransformUtils
   Vectorize
+  Passes
   )
 
 if (CUDAToolkit_FOUND)

--- a/llvm/lib/Transforms/Tapir/HipABI.cpp
+++ b/llvm/lib/Transforms/Tapir/HipABI.cpp
@@ -637,8 +637,8 @@ void HipABI::transformConstants(Function *Fn) {
         GEP->setOperand(GEP->getPointerOperandIndex(), asCast);
         LLVM_DEBUG(dbgs() << "\t\t\t\tnew gep:\n\t\t\t\t  " << *GEP << "\n");
       } else {
-        U->get()->dump();
-        U->getUser()->dump();
+        LLVM_DEBUG(dbgs() << U->get());
+        LLVM_DEBUG(dbgs() << U->getUser()); 
         assert(false && "unexpected use/user of gep.");
       }
     }


### PR DESCRIPTION
clang/lib/Frontend has a call to a Tapir << operator, which means it has to be linked against TapirOpts.

There's  unguarded checks to Value::dump in HipABI, which is disabled for release builds, so I've replaced them with LLVM_DEBUG calls. Note this means you don't have that output before assertion failure for release builds. Other options if that's important.

