### PR TITLE
[kitsune] Fix list of statically linked libraries

### DIFF
--- a/clang/lib/Tooling/DumpTool/CMakeLists.txt
+++ b/clang/lib/Tooling/DumpTool/CMakeLists.txt
@@ -13,4 +13,5 @@ target_link_libraries(clang-ast-dump
   clangFrontend
   clangSerialization
   clangToolingCore
+  LLVMTapirOpts
 )

--- a/clang/tools/arcmt-test/CMakeLists.txt
+++ b/clang/tools/arcmt-test/CMakeLists.txt
@@ -13,4 +13,5 @@ clang_target_link_libraries(arcmt-test
   clangFrontend
   clangLex
   clangSerialization
+  LLVMTapirOpts
   )

--- a/clang/tools/clang-diff/CMakeLists.txt
+++ b/clang/tools/clang-diff/CMakeLists.txt
@@ -13,4 +13,5 @@ clang_target_link_libraries(clang-diff
   clangSerialization
   clangTooling
   clangToolingASTDiff
+  LLVMTapirOpts
   )

--- a/clang/tools/clang-refactor/CMakeLists.txt
+++ b/clang/tools/clang-refactor/CMakeLists.txt
@@ -20,4 +20,5 @@ clang_target_link_libraries(clang-refactor
   clangTooling
   clangToolingCore
   clangToolingRefactoring
+  LLVMTapirOpts
   )

--- a/clang/tools/clang-rename/CMakeLists.txt
+++ b/clang/tools/clang-rename/CMakeLists.txt
@@ -16,6 +16,7 @@ clang_target_link_libraries(clang-rename
   clangTooling
   clangToolingCore
   clangToolingRefactoring
+  LLVMTapirOpts
   )
 
 install(FILES clang-rename.py

--- a/clang/tools/diagtool/CMakeLists.txt
+++ b/clang/tools/diagtool/CMakeLists.txt
@@ -16,4 +16,5 @@ clang_target_link_libraries(diagtool
   PRIVATE
   clangBasic
   clangFrontend
+  LLVMTapirOpts
   )

--- a/clang/unittests/AST/CMakeLists.txt
+++ b/clang/unittests/AST/CMakeLists.txt
@@ -49,6 +49,7 @@ clang_target_link_libraries(ASTTests
   clangLex
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(ASTTests

--- a/clang/unittests/AST/Interp/CMakeLists.txt
+++ b/clang/unittests/AST/Interp/CMakeLists.txt
@@ -10,6 +10,7 @@ clang_target_link_libraries(InterpTests
   clangFrontend
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
   target_link_libraries(InterpTests

--- a/clang/unittests/ASTMatchers/CMakeLists.txt
+++ b/clang/unittests/ASTMatchers/CMakeLists.txt
@@ -20,6 +20,7 @@ clang_target_link_libraries(ASTMatchersTests
   clangFrontend
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(ASTMatchersTests

--- a/clang/unittests/ASTMatchers/Dynamic/CMakeLists.txt
+++ b/clang/unittests/ASTMatchers/Dynamic/CMakeLists.txt
@@ -18,6 +18,7 @@ clang_target_link_libraries(DynamicASTMatchersTests
   clangFrontend
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(DynamicASTMatchersTests

--- a/clang/unittests/Analysis/CMakeLists.txt
+++ b/clang/unittests/Analysis/CMakeLists.txt
@@ -23,6 +23,7 @@ clang_target_link_libraries(ClangAnalysisTests
   clangLex
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(ClangAnalysisTests

--- a/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
+++ b/clang/unittests/Analysis/FlowSensitive/CMakeLists.txt
@@ -41,6 +41,7 @@ clang_target_link_libraries(ClangAnalysisFlowSensitiveTests
   clangLex
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(ClangAnalysisFlowSensitiveTests

--- a/clang/unittests/Introspection/CMakeLists.txt
+++ b/clang/unittests/Introspection/CMakeLists.txt
@@ -15,6 +15,7 @@ clang_target_link_libraries(IntrospectionTests
   clangFrontend
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 target_link_libraries(IntrospectionTests
   PRIVATE

--- a/clang/unittests/Rename/CMakeLists.txt
+++ b/clang/unittests/Rename/CMakeLists.txt
@@ -26,4 +26,5 @@ clang_target_link_libraries(ClangRenameTests
   clangTooling
   clangToolingCore
   clangToolingRefactoring
+  LLVMTapirOpts
   )

--- a/clang/unittests/Rewrite/CMakeLists.txt
+++ b/clang/unittests/Rewrite/CMakeLists.txt
@@ -12,4 +12,5 @@ clang_target_link_libraries(RewriteTests
   clangRewrite
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )

--- a/clang/unittests/Sema/CMakeLists.txt
+++ b/clang/unittests/Sema/CMakeLists.txt
@@ -21,6 +21,7 @@ clang_target_link_libraries(SemaTests
   clangSema
   clangSerialization
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(SemaTests

--- a/clang/unittests/Serialization/CMakeLists.txt
+++ b/clang/unittests/Serialization/CMakeLists.txt
@@ -25,4 +25,5 @@ clang_target_link_libraries(SerializationTests
   clangSerialization
   clangTooling
   clangASTMatchers
+  LLVMTapirOpts
   )

--- a/clang/unittests/StaticAnalyzer/CMakeLists.txt
+++ b/clang/unittests/StaticAnalyzer/CMakeLists.txt
@@ -33,6 +33,7 @@ clang_target_link_libraries(StaticAnalysisTests
   clangStaticAnalyzerCore
   clangStaticAnalyzerFrontend
   clangTooling
+  LLVMTapirOpts
   )
 
 target_link_libraries(StaticAnalysisTests

--- a/clang/unittests/Support/CMakeLists.txt
+++ b/clang/unittests/Support/CMakeLists.txt
@@ -12,4 +12,5 @@ clang_target_link_libraries(ClangSupportTests
   clangBasic
   clangFrontend
   clangSerialization
+  LLVMTapirOpts
   )

--- a/clang/unittests/Tooling/Syntax/CMakeLists.txt
+++ b/clang/unittests/Tooling/Syntax/CMakeLists.txt
@@ -21,6 +21,7 @@ clang_target_link_libraries(SyntaxTests
   clangTooling
   clangToolingCore
   clangToolingSyntax
+  LLVMTapirOpts
   )
 
 target_link_libraries(SyntaxTests

--- a/llvm/tools/bugpoint/CMakeLists.txt
+++ b/llvm/tools/bugpoint/CMakeLists.txt
@@ -18,6 +18,7 @@ set(LLVM_LINK_COMPONENTS
   ScalarOpts
   Support
   TapirOpts
+  Passes
   Target
   TargetParser
   TransformUtils


### PR DESCRIPTION
These changes are necessary if `LLVM_LINK_LLVM_DYLIB=false`