### PR TITLE
[kitsune] kit-config can query enabled frontends

### DIFF
--- a/kitsune/CMakeLists.txt
+++ b/kitsune/CMakeLists.txt
@@ -8,9 +8,12 @@
 cmake_minimum_required(VERSION 3.20)
 project(kitsune C CXX)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+
 include(ExternalProject)
 include(FetchContent)
 include(GetClangResourceDir)
+include(KitsuneUtils)
 
 if (WIN32)
   message(FATAL_ERROR "Kitsune is not supported on Windows")
@@ -18,7 +21,7 @@ endif ()
 
 set(KITSUNE_C_FRONTEND kitcc)
 set(KITSUNE_CXX_FRONTEND kit++)
-set(KITSUNE_Fortran_FRONTEND kitfort)
+set(KITSUNE_Fortran_FRONTEND kitfc)
 
 option(KITSUNE_INCLUDE_TESTS
   "Generate build targets for the Kitsune tests"
@@ -502,24 +505,25 @@ endif()
 set(KITSUNE_DEFAULT_TAPIR_RUNTIME "opencilk" CACHE STRING
   "Default Tapir runtime used by -ftapir.")
 
-# This is ugly because it creates a dangling symlink because this is executed
-# before clang is built. However, we force clang to be built, so we are sure
-# of it not dangling by the time everything is built.
-add_custom_target(${KITSUNE_C_FRONTEND} ALL
-  ${CMAKE_COMMAND} -E create_symlink
-  clang
-  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KITSUNE_C_FRONTEND})
+# If any more languages are enabled, a corresponding variable should be added
+# here. For instance, we may want to run Cuda code through Kitsune, in which
+# case, a Cuda frontend will need to be created similar to the C and C++ ones.
+set(KITSUNE_C_ENABLED OFF)
+set(KITSUNE_CXX_ENABLED OFF)
+set(KITSUNE_Fortran_ENABLED OFF)
 
-add_custom_target(${KITSUNE_CXX_FRONTEND} ALL
-  ${CMAKE_COMMAND} -E create_symlink
-  clang++
-  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${KITSUNE_CXX_FRONTEND})
+if ("clang" IN_LIST LLVM_ENABLE_PROJECTS)
+  set(KITSUNE_C_ENABLED ON)
+  setup_frontend_symlink(${KITSUNE_C_FRONTEND} clang)
 
-foreach (link ${KITSUNE_C_FRONTEND} ${KITSUNE_CXX_FRONTEND})
-  install(FILES
-    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${link}
-    DESTINATION ${CMAKE_INSTALL_BINDIR})
-endforeach()
+  set(KITSUNE_CXX_ENABLED ON)
+  setup_frontend_symlink(${KITSUNE_CXX_FRONTEND} clang++)
+endif ()
+
+if ("flang" IN_LIST LLVM_ENABLE_PROJECTS)
+  set(KITSUNE_Fortran_ENABLED ON)
+  setup_frontend_symlink(${KITSUNE_Fortran_FRONTEND} flang)
+endif ()
 
 add_subdirectory(configs)
 add_subdirectory(include/kitsune)

--- a/kitsune/cmake/modules/KitsuneUtils.cmake
+++ b/kitsune/cmake/modules/KitsuneUtils.cmake
@@ -1,3 +1,10 @@
+# ----------------------------- BEGIN MAYBE REMOVE -----------------------------
+#
+# Everything in this block (until END MAYBE REMOVE) is probably obsolete and, if
+# so, ought to be removed. These are only used in kitsune/examples, but those
+# are also likely obsolete now. But we need to double-check that before doing
+# so.
+
 #
 # Get a list of all enabled tapir runtime targets so we can
 # walk through each and do "stuff" (e.g., build an executable
@@ -63,3 +70,22 @@ function(add_tapir_dependency target abi)
   endif()
 
 endfunction()
+
+# ------------------------------ END MAYBE REMOVE ------------------------------
+
+# Setup a Kitsune frontend symlink (kitcc, kit++ etc.). symlink is the name of
+# the frontend. Target is the actual compiler that is the target of the symlink.
+macro(setup_frontend_symlink symlink target)
+  # This is ugly! The create_symlink command creates a dangling symlink because
+  # it is executed before clang (and perhaps flang) is built. However, if
+  # everything builds correctly, it will not be dangling. Obviously, a build
+  # failure will result in a dangling symlink in the build directory.
+  add_custom_target(${symlink} ALL
+    ${CMAKE_COMMAND} -E create_symlink
+    ${target}
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${symlink})
+
+  install(FILES
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${symlink}
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+endmacro()

--- a/kitsune/include/kitsune/Config/config.h.cmake
+++ b/kitsune/include/kitsune/Config/config.h.cmake
@@ -16,6 +16,16 @@
 // General configuration
 #define KITSUNE_LLD "${KITSUNE_LLD}"
 
+// Kitsune language support that has been enabled
+#cmakedefine01 KITSUNE_C_ENABLED
+#cmakedefine01 KITSUNE_CXX_ENABLED
+#cmakedefine01 KITSUNE_Fortran_ENABLED
+
+// The names of the Kitsune frontends
+#define KITSUNE_C_FRONTEND       "${KITSUNE_C_FRONTEND}"
+#define KITSUNE_CXX_FRONTEND     "${KITSUNE_CXX_FRONTEND}"
+#define KITSUNE_Fortran_FRONTEND "${KITSUNE_Fortran_FRONTEND}"
+
 // Kokkos configuration
 #cmakedefine01 KITSUNE_KOKKOS_ENABLED
 

--- a/kitsune/tools/kit-config/kit-config.cpp
+++ b/kitsune/tools/kit-config/kit-config.cpp
@@ -14,6 +14,8 @@
 
 #include "kitsune/Config/config.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
@@ -25,20 +27,40 @@ usage: kit-config <OPTION>... \n\
 Get configuration information about Kitsune\n\
 \n\
 Options:\n\
+  --c-frontend       Path to Kitsune's C frontend if it has been enabled\n\
+  --c++-frontend     Path to Kitsune's C++ frontend if it has been enabled\n\
   --cuda-prefix      The cuda prefix (only relevant if the Cuda tapir target was bbuilt)\n\
-  --cuda-target      Has the Cuda Tapir target been built (ON or OFF).\n\
-  --help             Print a summary of kit-config arguments.\n\
+  --cuda-target      Has the Cuda Tapir target been built (ON or OFF)\n\
+  --fortran-frontend Path to Kitsune's Fortran frontend if it has been enabled\n\
+  --frontends        The frontends that have been enabled\n\
+  --help             Print a summary of kit-config arguments\n\
   --hip-prefix       The rocm prefix (only relevant if the Hip tapir target was built)\n\
-  --hip-target       Has the Hip Tapir target been built (ON or OFF).\n\
-  --kokkos-mode      Is Kokkos mode enabled (ON or OFF).\n\
-  --opencilk-target  Has the OpenCilk Tapir target been built (ON or OFF).\n\
-  --openmp-target    Has the OpenMP Tapir target been built (ON or OFF).\n\
-  --qthreads-target  Has the Qthreads Tapir target been built (ON or OFF).\n\
-  --realm-target     Has the Realm Tapir target been built (ON or OFF).\n\
-  --tapir-targets    List all tapir targets that have been built.\n\
-  --version          Print LLVM version.\n";
+  --hip-target       Has the Hip Tapir target been built (ON or OFF)\n\
+  --kokkos-mode      Is Kokkos mode enabled (ON or OFF)\n\
+  --opencilk-target  Has the OpenCilk Tapir target been built (ON or OFF)\n\
+  --openmp-target    Has the OpenMP Tapir target been built (ON or OFF)\n\
+  --qthreads-target  Has the Qthreads Tapir target been built (ON or OFF)\n\
+  --realm-target     Has the Realm Tapir target been built (ON or OFF)\n\
+  --tapir-targets    List all tapir targets that have been built\n\
+  --version          Print LLVM version\n";
   if (exitWithFailure)
     exit(1);
+}
+
+// Get the path to the given frontend. @ref kitConfig is the full path to the
+// this kitConfig executable. The frontend is assumed to be in the same
+// directory as kitConfig.
+static std::string frontendPath(StringRef kitConfig, StringRef frontend) {
+  StringRef bin = sys::path::parent_path(kitConfig);
+  SmallString<256> path(bin);
+
+  sys::path::append(path, frontend);
+  return path.c_str();
+}
+
+// Get the full path to this executable.
+static std::string getExe(const char *argv0) {
+  return sys::fs::getMainExecutable(argv0, (void *)(intptr_t)getExe);
 }
 
 int main(int argc, char **argv) {
@@ -46,35 +68,52 @@ int main(int argc, char **argv) {
 
   raw_ostream &os = outs();
   for (int i = 1; i != argc; ++i) {
-    StringRef Arg = argv[i];
+    StringRef arg = argv[i];
 
-    if (Arg.starts_with("-")) {
+    if (arg.starts_with("-")) {
       hasAnyOption = true;
-      if (Arg == "--version") {
+      if (arg == "--version") {
         os << PACKAGE_VERSION << "\n";
-      } else if (Arg == "--help") {
+      } else if (arg == "--help") {
         usage(false);
-      } else if (Arg == "--cuda-prefix") {
+      } else if (arg == "--c-frontend") {
+        if (KITSUNE_C_ENABLED)
+          os << frontendPath(getExe(argv[0]), KITSUNE_C_FRONTEND) << "\n";
+      } else if (arg == "--c++-frontend") {
+        if (KITSUNE_CXX_ENABLED)
+          os << frontendPath(getExe(argv[0]), KITSUNE_CXX_FRONTEND) << "\n";
+      } else if (arg == "--cuda-prefix") {
         if (KITSUNE_CUDA_ENABLED)
           os << KITSUNE_CUDA_PREFIX << "\n";
-      } else if (Arg == "--cuda-target") {
+      } else if (arg == "--cuda-target") {
         os << (KITSUNE_CUDA_ENABLED ? "ON" : "OFF") << "\n";
-      } else if (Arg == "--hip-prefix") {
+      } else if (arg == "--fortran-frontend") {
+        if (KITSUNE_Fortran_ENABLED)
+          os << frontendPath(getExe(argv[0]), KITSUNE_Fortran_FRONTEND) << "\n";
+      } else if (arg == "--frontends") {
+        if (KITSUNE_C_ENABLED)
+          os << "C ";
+        if (KITSUNE_CXX_ENABLED)
+          os << "C++ ";
+        if (KITSUNE_Fortran_ENABLED)
+          os << "Fortran ";
+        os << "\n";
+      } else if (arg == "--hip-prefix") {
         if (KITSUNE_HIP_ENABLED)
           os << KITSUNE_HIP_PREFIX << "\n";
-      } else if (Arg == "--hip-target") {
+      } else if (arg == "--hip-target") {
         os << (KITSUNE_HIP_ENABLED ? "ON" : "OFF") << "\n";
-      } else if (Arg == "--kokkos-mode") {
+      } else if (arg == "--kokkos-mode") {
         os << (KITSUNE_KOKKOS_ENABLED ? "ON" : "OFF") << "\n";
-      } else if (Arg == "--opencilk-target") {
-        os << (KITSUNE_OPENCILK_ENABLED ? "ON" : "OFF")  << "\n";
-      } else if (Arg == "--openmp-target") {
+      } else if (arg == "--opencilk-target") {
+        os << (KITSUNE_OPENCILK_ENABLED ? "ON" : "OFF") << "\n";
+      } else if (arg == "--openmp-target") {
         os << (KITSUNE_OPENMP_ENABLED ? "ON" : "OFF") << "\n";
-      } else if (Arg == "--qthreads-target") {
+      } else if (arg == "--qthreads-target") {
         os << (KITSUNE_QTHREADS_ENABLED ? "ON" : "OFF") << "\n";
-      } else if (Arg == "--realm-target") {
+      } else if (arg == "--realm-target") {
         os << (KITSUNE_REALM_ENABLED ? "ON" : "OFF") << "\n";
-      } else if (Arg == "--tapir-targets") {
+      } else if (arg == "--tapir-targets") {
         os << KITSUNE_ENABLED_TAPIR_TARGETS << "\n";
       } else {
         usage();


### PR DESCRIPTION
In principle, not all frontends may be enabled in any given build. For instance, even after support for lowering Fortran' DO CONCURRENT loops to Tapir instructions is added, flang may still not be enabled. In this case, we want to be able to use kit-config to query whether the frontend has been built. The primary use for this is in the kitsune-test-suite which can then automatically enable/disable certain tests.

While implementing this, some code was also cleaned up.